### PR TITLE
Add XPC service process ID getter to HostedProcess

### DIFF
--- a/Sources/ProcessServiceClient/HostedProcess.swift
+++ b/Sources/ProcessServiceClient/HostedProcess.swift
@@ -122,6 +122,11 @@ public actor HostedProcess {
             return data
         }.value
     }
+    
+    /// The process ID (PID) of the XPC service itself (not its hosted executable)
+    public var serviceProcessID: Int {
+        Int(connection.processIdentifier)
+    }
 }
 
 extension HostedProcess {


### PR DESCRIPTION
Adds a `var serviceProcessID: Int` to HostedProcess.

The XPC service's PID is helpful when using ProcessService to host an LSP server because the [LSP initialize request](https://microsoft.github.io/language-server-protocol/specifications/lsp/3.17/specification/#initialize) requires the process ID of the client/parent process.